### PR TITLE
Skymail was dropping the parameters

### DIFF
--- a/bin/skymail.pl
+++ b/bin/skymail.pl
@@ -253,7 +253,7 @@ sub parse_event_mail {
 		$logger->debug("Part: ", $epart->content_type);
 		my $ct = $epart->content_type;
 		my $payload = $epart->body;
-		if ($ct =~ m/text\/plain/ ) {
+		if ($ct =~ m/text\/plain/i ) {
 			$logger->debug("Text", $epart->body);
 			my $pair = {
 				$ct => $payload


### PR DESCRIPTION
In the bin/skymail.pl file there was a bug causing no parameters to be passed from the email to the event. This bug was on line #205. $params was being assigned to {}. It may be more desirable to just pass $params into the to_post function.
