### PR TITLE
pass content-type header in xdi raw so that a valid response from an xdi server will be received.

### DIFF
--- a/Kynetx/Persistence/KXDI.pm
+++ b/Kynetx/Persistence/KXDI.pm
@@ -381,7 +381,8 @@ sub _raw {
 	if (defined $context) {
 		$cheader .= ';contexts=1';
 	}
-	$request->header('accept' => $cheader);
+    # xdi server requires a Content-Type of application/json+xdi or it will not respond properly.
+	$request->header('accept' => $cheader, 'content-type' => 'application/json+xdi');
 	$request->content($xdistring);
 	my $response = $ua->request($request);
 	my $code = $response->code;


### PR DESCRIPTION
So the XDI server I'm using now requires that the Content-Type header be set to 'application/json+xdi' or it will not process an XDI message. I added the header to the request before it gets sent out. It would be way easier if XDI raw would do this for me rather than having to change all the places where I'm calling xdi:raw(). So I added it to the _raw subroutine. If this was rolled to the production engine it would make me so happy inside.

Thanks,

AKO