### PR TITLE
Actions should be optional even if the rule has a where clause

### DIFF
--- a/parser/RuleSet.g
+++ b/parser/RuleSet.g
@@ -1441,7 +1441,8 @@ event_explicit returns[HashMap result]
 		tmp.put("filters",filters);
 		$result = tmp;
 	}
-	| op=(VAR|OTHER_OPERATORS) WHERE (ee = event_expression{exps.add(ee.result);}(ee2 = event_expression{exps.add(ee2.result);})* ) set=setting? {
+	// | op=(VAR|OTHER_OPERATORS) WHERE (ee = event_expression{exps.add(ee.result);}(ee2 = event_expression{exps.add(ee2.result);})* ) set=setting? {
+    | op=(VAR|OTHER_OPERATORS) WHERE (ef = event_filter{filters.add(ef.result);}(ef2=event_filter{filters.add(ef2.result);})* )  set=setting? {
 		HashMap tmp = new HashMap();
 		//tmp.put("domain",$dom.text);
 		tmp.put("type","prim_event");
@@ -1535,7 +1536,8 @@ event_pageview returns[HashMap result]
 	ArrayList filters = new ArrayList();
 	ArrayList exps = new ArrayList();
 }
-	: op=PAGEVIEW WHERE (ee = event_expression{exps.add(ee.result);}(ee2 = event_expression{exps.add(ee2.result);})* ) set=setting? {
+	// : op=PAGEVIEW WHERE (ee = event_expression{exps.add(ee.result);}(ee2 = event_expression{exps.add(ee2.result);})* ) set=setting? {
+    : op=PAGEVIEW WHERE (ef = event_filter{filters.add(ef.result);}(ef2=event_filter{filters.add(ef2.result);})* ) set=setting? {
 		HashMap tmp = new HashMap();
 		//tmp.put("domain",$dom.text);
 		tmp.put("type","prim_event");


### PR DESCRIPTION
This is my attempt at fixing #62. I'm by no means an expert on antlr but I want to see if my thought here works. The thought being that only the parser code referencing `WHERE` includes `event_expression`, all others include `event_filter`. It looks like, if I'm understanding correctly, that `event_expression` is requiring an action? 

Anyway, if nothing else this is a starting point from which we can make a better solution.

Sidenote: How do we test this effectively? I'd like to avoid standing up a VM just for a local KRE environment (if possible). Making a [KRE docker image](https://github.com/kre/kre_standalone) sounds promising.